### PR TITLE
이메일 인증이 안 됐음에도 Auth는 들어가 기존회원이라 인식하는 문제 해결

### DIFF
--- a/app/src/main/java/smu/miso/signup/SignUpEmailActivity.kt
+++ b/app/src/main/java/smu/miso/signup/SignUpEmailActivity.kt
@@ -2,6 +2,7 @@ package smu.miso.signup
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.google.firebase.auth.FirebaseAuth
@@ -56,11 +57,20 @@ class SignUpEmailActivity : AppCompatActivity() {
                     moveNextPage()
                 }
                 else {
-                    Toast.makeText(
-                        this@SignUpEmailActivity,
-                        "이미 가입한 학번 입니다. 다시 확인해 주세요.",
-                        Toast.LENGTH_LONG
-                    ).show()
+                    val currentUser = auth.currentUser
+                    //auth는 등록됐고, email인증이 안 됐다면, 이메일 인증 화면으로 다시 가게끔
+                    if(verifiedEmail() == false && currentUser != null){
+                        currentUser.updatePassword(password)
+                        moveNextPage()
+                    }
+                    //auth도 있고, email인증도 된 경우
+                    else {
+                        Toast.makeText(
+                            this@SignUpEmailActivity,
+                            "이미 가입한 학번 입니다. 다시 확인해 주세요.",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
                 }
             }
     }

--- a/app/src/main/java/smu/miso/signup/VerifyEmailActivity.kt
+++ b/app/src/main/java/smu/miso/signup/VerifyEmailActivity.kt
@@ -133,10 +133,11 @@ class VerifyEmailActivity : AppCompatActivity() {
             CloudFunctions.hideKeyboard(this)
         }
     }
-    override fun onBackPressed() {
-        // 뒤로가기 버튼 클릭
-        user?.delete()
-        val intent = Intent(this, SignUpEmailActivity::class.java)
-        startActivity(intent)
-    }
+//    //이론상 이게 없어도 될 거 같음
+//    override fun onBackPressed() {
+//        // 뒤로가기 버튼 클릭
+//        user?.delete()
+//        val intent = Intent(this, SignUpEmailActivity::class.java)
+//        startActivity(intent)
+//    }
 }

--- a/local.properties
+++ b/local.properties
@@ -4,5 +4,5 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Thu Sep 03 11:48:07 KST 2020
-sdk.dir=/Users/kkangjee/Library/Android/sdk
+#Thu Sep 03 14:29:07 KST 2020
+sdk.dir=C\:\\Users\\Park\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
학번과 비밀번호 작성 > 이메일 인증화면 > 뒤로가기 또는 종료
> 다시 회원가입 누르고 학번과 비밀번호 작성 > "이미 있는 회원입니다"

이 문제를

학번과 비밀번호 작성 > 이메일 인증화면 > 뒤로가기 또는 종료
> 다시 회원가입 누르고 학번과 비밀번호 작성 > (1) 회원의 비밀번호를 현재 적은 비밀번호로 업데이트, (2) 이메일 인증화면으로 넘어감 